### PR TITLE
Fixed menu bugs on new resources page

### DIFF
--- a/menu.html
+++ b/menu.html
@@ -9,7 +9,7 @@
       <ul class="navbar-nav ml-auto">
         <li id="home" class="nav-item"><a href="/index.html" class="nav-link">Home</a></li>
         <li id="about" class="nav-item"><a href="/about.html" class="nav-link">About</a></li>
-        <li id="recaps" class="nav-item"><a href="/resources/index.html" class="nav-link">Resources</a></li>
+        <li id="resources" class="nav-item"><a href="/resources/index.html" class="nav-link">Resources</a></li>
         <li id="curriculum" class="nav-item"><a href="/curriculum.html" class="nav-link">Curriculum</a></li>
         <li id="events" class="nav-item"><a href="/events/index.html" class="nav-link">Events</a></li>
         <li id="contact" class="nav-item"><a href="/contact.html" class="nav-link">Contact</a></li>

--- a/resources/cpp.html
+++ b/resources/cpp.html
@@ -32,7 +32,7 @@
   </head>
 
   <body>
-    <div w3-include-html="/menuTemp.html" active-item="resources"></div>
+    <div w3-include-html="/menu.html" active-item="resources"></div>
     <!-- END nav -->
 
     <section class="ftco-section">

--- a/resources/html-css.html
+++ b/resources/html-css.html
@@ -32,7 +32,7 @@
   </head>
 
   <body>
-    <div w3-include-html="/menuTemp.html" active-item="resources"></div>
+    <div w3-include-html="/menu.html" active-item="resources"></div>
     <!-- END nav -->
 
     <section class="ftco-section">

--- a/resources/index.html
+++ b/resources/index.html
@@ -32,7 +32,7 @@
   </head>
 
   <body>
-    <div w3-include-html="/menuTemp.html" active-item="resources"></div>
+    <div w3-include-html="/menu.html" active-item="resources"></div>
     <!-- END nav -->
 
     <section class="ftco-section">

--- a/resources/java.html
+++ b/resources/java.html
@@ -32,7 +32,7 @@
   </head>
 
   <body>
-    <div w3-include-html="/menuTemp.html" active-item="resources"></div>
+    <div w3-include-html="/menu.html" active-item="resources"></div>
     <!-- END nav -->
 
     <section class="ftco-section">

--- a/resources/python.html
+++ b/resources/python.html
@@ -32,7 +32,7 @@
   </head>
 
   <body>
-    <div w3-include-html="/menuTemp.html" active-item="resources"></div>
+    <div w3-include-html="/menu.html" active-item="resources"></div>
     <!-- END nav -->
     <section class="ftco-section">
       <div class="container">


### PR DESCRIPTION
Linked the menus properly and changed the menu ID from "recaps" to "resources"